### PR TITLE
Problem with 'Bad host/IP'.

### DIFF
--- a/templates/etc/squid3/squid.conf.erb
+++ b/templates/etc/squid3/squid.conf.erb
@@ -645,8 +645,8 @@
 # Recommended minimum configuration:
 #
 acl manager proto cache_object
-acl localhost src 127.0.0.1/32 ::1
-acl to_localhost dst 127.0.0.0/8 0.0.0.0/32 ::1
+acl localhost src 127.0.0.1/32
+acl to_localhost dst 127.0.0.0/8 0.0.0.0/32
 
 # Example rule allowing access from your local networks.
 # Adapt to list your (internal) IP networks from where browsing


### PR DESCRIPTION
I don't know if this is environment specific, but I get this error on Ubuntu 10.04:

 aclParseIpData: Bad host/IP: '::1'

Removing '::1' from the localhost adresses fixes the problem.
