### PR TITLE
Multiple localnets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,11 @@ Templated puppet class to allow for the definition of a squid HTTP proxy service
 Based upon [Puppet Labs - Squid Configuration Patterns].
 
 [Puppet Labs - Squid Configuration Patterns]: http://projects.puppetlabs.com/projects/1/wiki/Squid_Configuration_Patterns
+
+Usage
+=====
+
+    class { 'squid':
+        localnet_src => ['10.0.0.0/8,
+                         '192.168.0.0/16'],
+    }

--- a/templates/etc/squid3/squid.conf.erb
+++ b/templates/etc/squid3/squid.conf.erb
@@ -656,7 +656,14 @@ acl to_localhost dst 127.0.0.0/8 0.0.0.0/32<% if @ipv6 %> ::1<% end %>
 #acl localnet src 192.168.0.0/16    # RFC1918 possible internal network
 #acl localnet src fc00::/7       # RFC 4193 local private network range
 #acl localnet src fe80::/10      # RFC 4291 link-local (directly plugged) machines
+<% if @localnet_src.is_a? Array %>
+    <% @localnet_src.each do |net| %>
+acl localnet src <%= net %>
+    <% end %>
+<% else %>
 acl localnet src <%= @localnet_src %>
+<% end %>
+
 
 acl SSL_ports port 443
 acl Safe_ports port 80      # http


### PR DESCRIPTION
This functionality was already 'there' in the sense that we could put space separated subnets into localnet_src, but I found that less than ideal. This doesn't break compatibility for anyone already using strings like that. 
